### PR TITLE
Reduce docker image size by 16% (11.6 MB to 9.72 MB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM alpine:3.15
-MAINTAINER Jujhar Singh <jujhar+docker@jujhar.com>
 
-LABEL org.label-schema.vcs-url="e.g. https://github.com/jujhars13/docker-ssh-tunnel"
+LABEL maintainer="Jujhar Singh jujhar+docker@jujhar.com" \
+      org.label-schema.vcs-url="e.g. https://github.com/jujhars13/docker-ssh-tunnel"
 
-RUN apk --no-cache add openssh-client bash
+RUN apk --no-cache add openssh-client
 
 ADD run.sh /run.sh
 
 # Security fix for CVE-2016-0777 and CVE-2016-0778
 RUN echo -e 'Host *\nUseRoaming no' >> /etc/ssh/ssh_config
 
-ENTRYPOINT ["sh", "-c", "/run.sh"]
+ENTRYPOINT ["/bin/sh", "-c", "/run.sh"]


### PR DESCRIPTION
- Replace deprecated MAINTAINER with LABEL instruction
- Use shell within alpine linux to execute run.sh instead of bash
- Upgrading to alpine 3.16 increases the size to 10.5 MB. Haven't included that in this PR. 